### PR TITLE
chore: bump bref layer to arm-php-84-fpm:39

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -19,7 +19,7 @@ variable "domain" {
 variable "bref_fpm_layer_arn" {
   description = "Bref arm-php-84-fpm Lambda layer ARN (ap-northeast-1)"
   type        = string
-  default     = "arn:aws:lambda:ap-northeast-1:534081306603:layer:arm-php-84-fpm:28"
+  default     = "arn:aws:lambda:ap-northeast-1:534081306603:layer:arm-php-84-fpm:39"
 }
 
 variable "log_retention_days" {


### PR DESCRIPTION
## Summary
- 最新の Bref layer バージョン (v39) に更新。初回 terraform apply で v39 が既に使われているため、repo の state と実インフラを揃える

## Test plan
- [x] `aws lambda get-layer-version --version-number 39` で v39 の存在確認済み
- [ ] CI: test-api + build-web 緑
- [ ] squash merge 後、CD の deploy-infra が no-op で完了すること