### PR TITLE
fix: migrate to bref v3 unified layer + fix CD race condition

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -89,25 +89,18 @@ jobs:
           find vendor/aws/aws-sdk-php -type d \( -name 'tests' -o -name 'docs' -o -name 'examples' \) -prune -exec rm -rf {} + || true
           zip -qr ../lambda.zip . -x '*.git*' 'tests/*' '.env' '.env.*' 'phpunit.xml' '.phpunit.cache/*' 'storage/logs/*'
 
+      - name: Wait for any pending update
+        run: aws lambda wait function-updated --function-name ${{ env.LAMBDA_FUNCTION }}
+
       - name: Deploy Lambda code
         run: |
           aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION }} \
             --zip-file fileb://lambda.zip \
-            --no-cli-pager
+            --output json > /dev/null
 
-      - name: Set Lambda APP_KEY (only if placeholder)
-        run: |
-          CURRENT=$(aws lambda get-function-configuration \
-            --function-name ${{ env.LAMBDA_FUNCTION }} \
-            --query 'Environment.Variables.APP_KEY' --output text)
-          if [[ "$CURRENT" == *placeholder* ]]; then
-            NEW_KEY="base64:$(openssl rand -base64 32)"
-            aws lambda update-function-configuration \
-              --function-name ${{ env.LAMBDA_FUNCTION }} \
-              --environment "Variables={APP_KEY=$NEW_KEY}" \
-              --no-cli-pager
-          fi
+      - name: Wait for code update to finish
+        run: aws lambda wait function-updated --function-name ${{ env.LAMBDA_FUNCTION }}
 
   deploy-web:
     needs: detect-changes

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -9,6 +9,12 @@ data "archive_file" "placeholder" {
   }
 }
 
+# Stable APP_KEY generated and kept in tfstate (encrypted S3 backend)
+resource "random_password" "app_key" {
+  length  = 32
+  special = false
+}
+
 resource "aws_lambda_function" "api" {
   function_name = "${var.project}-api"
   role          = aws_iam_role.lambda.arn
@@ -18,7 +24,7 @@ resource "aws_lambda_function" "api" {
   timeout       = 28
   memory_size   = 512
 
-  layers = [var.bref_fpm_layer_arn]
+  layers = [var.bref_layer_arn]
 
   filename         = data.archive_file.placeholder.output_path
   source_code_hash = data.archive_file.placeholder.output_base64sha256
@@ -29,11 +35,12 @@ resource "aws_lambda_function" "api" {
 
   environment {
     variables = {
+      BREF_RUNTIME                  = "fpm"
       APP_NAME                      = var.project
       APP_ENV                       = "production"
       APP_DEBUG                     = "false"
       APP_URL                       = "https://${var.domain}"
-      APP_KEY                       = "base64:placeholder-set-by-deploy"
+      APP_KEY                       = "base64:${base64encode(random_password.app_key.result)}"
       LOG_CHANNEL                   = "stderr"
       LOG_LEVEL                     = "warning"
       DB_CONNECTION                 = "null"
@@ -43,7 +50,6 @@ resource "aws_lambda_function" "api" {
       BROADCAST_CONNECTION          = "log"
       FILESYSTEM_DISK               = "local"
       DYNAMODB_TABLE                = aws_dynamodb_table.notes.name
-      AWS_REGION_APP                = var.region
       BURNNOTE_MAX_CIPHERTEXT_BYTES = "16384"
       BURNNOTE_MAX_EXPIRES_SEC      = "604800"
     }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -16,10 +16,10 @@ variable "domain" {
   default     = "burnnote.tommykeyapp.com"
 }
 
-variable "bref_fpm_layer_arn" {
-  description = "Bref arm-php-84-fpm Lambda layer ARN (ap-northeast-1)"
+variable "bref_layer_arn" {
+  description = "Bref v3 arm-php-84 unified Lambda layer ARN (ap-northeast-1). Runtime mode (fpm/function/console) is controlled via BREF_RUNTIME env var."
   type        = string
-  default     = "arn:aws:lambda:ap-northeast-1:534081306603:layer:arm-php-84-fpm:39"
+  default     = "arn:aws:lambda:ap-northeast-1:873528684822:layer:arm-php-84:17"
 }
 
 variable "log_retention_days" {

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/archive"
       version = "~> 2.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
本番 Lambda の INIT が `libreadline.so.6: cannot open shared object file` で落ちていた件を修正。

### 根本原因
Bref v2 layer (`534081306603:arm-php-84-fpm`) は Amazon Linux 2 向けビルドで、`libreadline.so.6` を要求する。しかし Lambda runtime を `provided.al2023` (AL2023 = libreadline.so.8) に指定していたため、動的リンクに失敗していた。

### 修正内容
1. **Bref v3 unified layer へ移行**
   - Account: `534081306603` → `873528684822`
   - Layer name: `arm-php-84-fpm` → `arm-php-84` (v3 は単一 layer)
   - `BREF_RUNTIME=fpm` 環境変数で FPM モード指定
   - Ref: https://bref.sh/docs/upgrading/v3

2. **APP_KEY を random_password でtfstate管理**
   - 以前: placeholder → CD で `openssl rand` で上書き → race condition
   - 今: Terraform の `random_password` で安定生成、tfstate に保存

3. **CD の race condition 修正**
   - `update-function-code` → 直後に `update-function-configuration` すると ResourceConflictException
   - `aws lambda wait function-updated` を前後に追加

4. `AWS_REGION_APP` 削除 (Lambda 予約環境変数 `AWS_REGION` を aws-sdk-php が自動参照)

## Test plan
- [x] 本番 Lambda を v3 layer + BREF_RUNTIME=fpm で手動更新し、`https://burnnote.tommykeyapp.com/api/notes` で create/consume/gone フロー疎通確認済
- [ ] CI: test-api + build-web 緑
- [ ] squash merge 後、CD の deploy-infra が tfstate 更新のみで完了
- [ ] 手動 workflow_dispatch で deploy-api/web が完走