### PR TITLE
feat(web): make header sticky

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -10,7 +10,7 @@
 </svelte:head>
 
 <div class="min-h-screen bg-background text-foreground">
-	<header class="border-b border-[color:var(--color-border)]">
+	<header class="sticky top-0 z-40 border-b border-[color:var(--color-border)] bg-background/80 backdrop-blur">
 		<div class="mx-auto flex max-w-3xl items-center justify-between px-6 py-4">
 			<a href="/" class="text-xl font-bold tracking-tight">burnnote</a>
 			<span class="text-sm text-muted-foreground">one-time secrets</span>


### PR DESCRIPTION
## Summary
- ヘッダーを sticky top-0 に固定し、背景を半透明 + blur で重なりが自然になるよう調整

## Test plan
- [x] `pnpm build` & `pnpm check` 通過
- [ ] CI: build-web + test-api 緑
- [ ] merge 後 CD 経由で CloudFront にデプロイ、https://burnnote.tommykeyapp.com でスクロール時にヘッダーが追従することを確認