### PR TITLE
feat(web): add dark/light theme toggle

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
 		"@tailwindcss/vite": "^4.2.2",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
+		"mode-watcher": "^1.1.0",
 		"phosphor-svelte": "^3.1.0",
 		"shadcn-svelte": "^1.2.7",
 		"svelte": "^5.55.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      mode-watcher:
+        specifier: ^1.1.0
+        version: 1.1.0(svelte@5.55.4)
       phosphor-svelte:
         specifier: ^3.1.0
         version: 3.1.0(svelte@5.55.4)(vite@8.0.9(jiti@2.6.1))
@@ -535,6 +538,11 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mode-watcher@1.1.0:
+    resolution: {integrity: sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g==}
+    peerDependencies:
+      svelte: ^5.27.0
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -583,6 +591,16 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  runed@0.23.4:
+    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
+    peerDependencies:
+      svelte: ^5.7.0
+
+  runed@0.25.0:
+    resolution: {integrity: sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg==}
+    peerDependencies:
+      svelte: ^5.7.0
+
   runed@0.35.1:
     resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
     peerDependencies:
@@ -629,6 +647,12 @@ packages:
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.30.2
+
+  svelte-toolbelt@0.7.1:
+    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.0.0
 
   svelte@5.55.4:
     resolution: {integrity: sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==}
@@ -1094,6 +1118,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mode-watcher@1.1.0(svelte@5.55.4):
+    dependencies:
+      runed: 0.25.0(svelte@5.55.4)
+      svelte: 5.55.4
+      svelte-toolbelt: 0.7.1(svelte@5.55.4)
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -1144,6 +1174,16 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.16
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.16
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.16
+
+  runed@0.23.4(svelte@5.55.4):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.55.4
+
+  runed@0.25.0(svelte@5.55.4):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.55.4
 
   runed@0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.4)(vite@8.0.9(jiti@2.6.1)))(svelte@5.55.4)(typescript@6.0.3)(vite@8.0.9(jiti@2.6.1)))(svelte@5.55.4):
     dependencies:
@@ -1200,6 +1240,13 @@ snapshots:
       svelte: 5.55.4
     transitivePeerDependencies:
       - '@sveltejs/kit'
+
+  svelte-toolbelt@0.7.1(svelte@5.55.4):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.23.4(svelte@5.55.4)
+      style-to-object: 1.0.14
+      svelte: 5.55.4
 
   svelte@5.55.4:
     dependencies:

--- a/web/src/lib/components/ThemeToggle.svelte
+++ b/web/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { mode, setMode, userPrefersMode } from 'mode-watcher';
+	import Sun from 'phosphor-svelte/lib/Sun';
+	import Moon from 'phosphor-svelte/lib/Moon';
+	import Monitor from 'phosphor-svelte/lib/Monitor';
+
+	function cycle() {
+		const current = userPrefersMode.current;
+		const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
+		setMode(next);
+	}
+
+	const label = $derived.by(() => {
+		const u = userPrefersMode.current;
+		if (u === 'system') return `Theme: system (${mode.current})`;
+		return `Theme: ${u}`;
+	});
+</script>
+
+<button
+	type="button"
+	onclick={cycle}
+	aria-label={label}
+	title={label}
+	class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-[color:var(--color-border)] bg-background transition-colors hover:bg-accent hover:text-accent-foreground"
+>
+	{#if userPrefersMode.current === 'light'}
+		<Sun size={18} weight="regular" />
+	{:else if userPrefersMode.current === 'dark'}
+		<Moon size={18} weight="regular" />
+	{:else}
+		<Monitor size={18} weight="regular" />
+	{/if}
+</button>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import '../app.css';
+	import { ModeWatcher } from 'mode-watcher';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 
 	let { children } = $props();
 </script>
+
+<ModeWatcher />
 
 <svelte:head>
 	<title>burnnote — one-time secrets</title>
@@ -10,10 +14,15 @@
 </svelte:head>
 
 <div class="min-h-screen bg-background text-foreground">
-	<header class="sticky top-0 z-40 border-b border-[color:var(--color-border)] bg-background/80 backdrop-blur">
+	<header
+		class="sticky top-0 z-40 border-b border-[color:var(--color-border)] bg-background/80 backdrop-blur"
+	>
 		<div class="mx-auto flex max-w-3xl items-center justify-between px-6 py-4">
 			<a href="/" class="text-xl font-bold tracking-tight">burnnote</a>
-			<span class="text-sm text-muted-foreground">one-time secrets</span>
+			<div class="flex items-center gap-3">
+				<span class="hidden text-sm text-muted-foreground sm:inline">one-time secrets</span>
+				<ThemeToggle />
+			</div>
 		</div>
 	</header>
 	<main class="mx-auto max-w-3xl px-6 py-10">


### PR DESCRIPTION
## Summary
- `mode-watcher` 導入でダーク/ライト/システム追従の 3 値テーマ切替を実装
- ヘッダー右にトグルボタン追加 (Sun/Moon/Monitor アイコン)
- mode-watcher が FOUC 防止スクリプトを自動で `<head>` に注入するため、SvelteKit adapter-static でも初回描画のチラつきなし

## Test plan
- [x] `pnpm build` & `pnpm check` 通過
- [ ] CI: test-api + build-web 緑
- [ ] merge 後、https://burnnote.tommykeyapp.com でテーマボタンが Light → Dark → System サイクル
- [ ] リロードで選択テーマが維持
- [ ] System モード時、OS の prefers-color-scheme 変更で追従