### PR TITLE
feat(web): add Japanese/English i18n

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { t } from '$lib/i18n/index.svelte';
+
 export type CreateResponse = { id: string; expires_at: number };
 export type ReadResponse = { ciphertext: string; iv: string };
 
@@ -11,7 +13,7 @@ export async function createNote(
 		headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
 		body: JSON.stringify({ ciphertext, iv, expires_in: expiresIn })
 	});
-	if (!res.ok) throw new Error(`create failed: ${res.status}`);
+	if (!res.ok) throw new Error(t('errors.create_failed', { status: res.status }));
 	return res.json();
 }
 
@@ -27,6 +29,6 @@ export async function consumeNote(id: string): Promise<ReadResponse | 'gone'> {
 		headers: { Accept: 'application/json' }
 	});
 	if (res.status === 410 || res.status === 404) return 'gone';
-	if (!res.ok) throw new Error(`read failed: ${res.status}`);
+	if (!res.ok) throw new Error(t('errors.read_failed', { status: res.status }));
 	return res.json();
 }

--- a/web/src/lib/components/LocaleSwitcher.svelte
+++ b/web/src/lib/components/LocaleSwitcher.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { getLocale, setLocale, type Locale } from '$lib/i18n/index.svelte';
+
+	function onChange(e: Event) {
+		const v = (e.currentTarget as HTMLSelectElement).value as Locale;
+		setLocale(v);
+	}
+</script>
+
+<select
+	value={getLocale()}
+	onchange={onChange}
+	aria-label="Language"
+	class="h-9 rounded-md border border-[color:var(--color-border)] bg-background px-2 text-sm"
+>
+	<option value="en">EN</option>
+	<option value="ja">JA</option>
+</select>

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1,0 +1,48 @@
+{
+	"meta": {
+		"title": "burnnote — one-time secrets",
+		"description": "Share secrets that self-destruct after one read."
+	},
+	"nav": {
+		"tagline": "one-time secrets"
+	},
+	"footer": {
+		"note": "Encrypted in your browser. The server never sees the key."
+	},
+	"create": {
+		"heading": "Share a one-time secret",
+		"description": "The secret is encrypted in your browser. The server stores only the ciphertext. The URL is destroyed after a single read.",
+		"label_secret": "Secret",
+		"placeholder": "Type or paste a secret…",
+		"label_expires": "Expires in",
+		"expiry": {
+			"5m": "5 minutes",
+			"1h": "1 hour",
+			"1d": "1 day",
+			"7d": "7 days"
+		},
+		"submit": "Create one-time URL",
+		"submitting": "Encrypting…",
+		"result_note": "Share this URL. It works only once.",
+		"copy": "Copy",
+		"copied": "Copied!",
+		"reset": "Create another"
+	},
+	"reveal": {
+		"checking": "Checking…",
+		"no_key_title": "No key in URL",
+		"no_key_body": "This URL is missing the decryption key (the part after #). Without it the secret cannot be decrypted.",
+		"gone_title": "This secret is gone",
+		"gone_body": "It has been read once, or it has expired.",
+		"ready_title": "A secret is waiting for you",
+		"ready_body": "Once revealed, it will be permanently deleted from the server. You will not be able to re-open this link.",
+		"reveal_button": "Reveal once",
+		"revealing": "Decrypting…",
+		"destroyed_note": "This secret has been destroyed on the server.",
+		"error_title": "Failed to decrypt"
+	},
+	"errors": {
+		"create_failed": "create failed: {status}",
+		"read_failed": "read failed: {status}"
+	}
+}

--- a/web/src/lib/i18n/index.svelte.ts
+++ b/web/src/lib/i18n/index.svelte.ts
@@ -1,0 +1,60 @@
+import en from './en.json';
+import ja from './ja.json';
+
+export type Locale = 'en' | 'ja';
+
+const messages = { en, ja } as const;
+
+const STORAGE_KEY = 'burnnote-locale';
+
+type MessageNode = string | { [k: string]: MessageNode };
+
+let locale = $state<Locale>('en');
+
+export function getLocale(): Locale {
+	return locale;
+}
+
+export function setLocale(next: Locale): void {
+	locale = next;
+	if (typeof window !== 'undefined') {
+		try {
+			localStorage.setItem(STORAGE_KEY, next);
+		} catch {
+			// ignore storage errors
+		}
+		document.documentElement.lang = next;
+	}
+}
+
+export function initLocale(): void {
+	if (typeof window === 'undefined') return;
+	let stored: string | null = null;
+	try {
+		stored = localStorage.getItem(STORAGE_KEY);
+	} catch {
+		// ignore
+	}
+	if (stored === 'en' || stored === 'ja') {
+		setLocale(stored);
+		return;
+	}
+	const nav = navigator.language?.toLowerCase() ?? '';
+	setLocale(nav.startsWith('ja') ? 'ja' : 'en');
+}
+
+export function t(key: string, params?: Record<string, string | number>): string {
+	const parts = key.split('.');
+	let node: MessageNode = messages[locale];
+	for (const p of parts) {
+		if (typeof node === 'string') return key;
+		node = node[p];
+		if (node === undefined) return key;
+	}
+	if (typeof node !== 'string') return key;
+	if (!params) return node;
+	return node.replace(/\{(\w+)\}/g, (_, k) => {
+		const v = params[k];
+		return v === undefined ? `{${k}}` : String(v);
+	});
+}

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -1,0 +1,48 @@
+{
+	"meta": {
+		"title": "burnnote — 一度だけ読めるシークレット共有",
+		"description": "1 回読まれたら消えるシークレットを共有できます。"
+	},
+	"nav": {
+		"tagline": "一度だけ読めるシークレット"
+	},
+	"footer": {
+		"note": "暗号化はブラウザ内で完結。サーバーは鍵を知りません。"
+	},
+	"create": {
+		"heading": "一度だけ読めるシークレットを共有",
+		"description": "シークレットはブラウザ内で暗号化され、サーバーは暗号文のみを保持します。共有 URL は 1 回開かれた時点で消えます。",
+		"label_secret": "シークレット",
+		"placeholder": "共有したい内容を入力または貼り付け…",
+		"label_expires": "有効期限",
+		"expiry": {
+			"5m": "5 分",
+			"1h": "1 時間",
+			"1d": "1 日",
+			"7d": "7 日"
+		},
+		"submit": "一度だけ開ける URL を作成",
+		"submitting": "暗号化中…",
+		"result_note": "この URL を共有してください。1 回だけ開けます。",
+		"copy": "コピー",
+		"copied": "コピーしました！",
+		"reset": "もう 1 つ作成"
+	},
+	"reveal": {
+		"checking": "確認中…",
+		"no_key_title": "URL に鍵がありません",
+		"no_key_body": "この URL には復号用の鍵 (# 以降の部分) が含まれていません。鍵がないとシークレットは復号できません。",
+		"gone_title": "このシークレットはもう存在しません",
+		"gone_body": "すでに開かれたか、有効期限が切れています。",
+		"ready_title": "シークレットが届いています",
+		"ready_body": "開いた瞬間にサーバーから完全に削除されます。この URL は 2 度目は開けません。",
+		"reveal_button": "開く (1 回だけ)",
+		"revealing": "復号中…",
+		"destroyed_note": "シークレットはサーバーから削除されました。",
+		"error_title": "復号に失敗しました"
+	},
+	"errors": {
+		"create_failed": "作成に失敗しました: {status}",
+		"read_failed": "読み取りに失敗しました: {status}"
+	}
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
 	import '../app.css';
+	import { onMount } from 'svelte';
 	import { ModeWatcher } from 'mode-watcher';
 	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import LocaleSwitcher from '$lib/components/LocaleSwitcher.svelte';
+	import { initLocale, t } from '$lib/i18n/index.svelte';
 
 	let { children } = $props();
+
+	onMount(() => {
+		initLocale();
+	});
 </script>
 
 <ModeWatcher />
 
 <svelte:head>
-	<title>burnnote — one-time secrets</title>
-	<meta name="description" content="Share secrets that self-destruct after one read." />
+	<title>{t('meta.title')}</title>
+	<meta name="description" content={t('meta.description')} />
 </svelte:head>
 
 <div class="min-h-screen bg-background text-foreground">
@@ -19,8 +26,9 @@
 	>
 		<div class="mx-auto flex max-w-3xl items-center justify-between px-6 py-4">
 			<a href="/" class="text-xl font-bold tracking-tight">burnnote</a>
-			<div class="flex items-center gap-3">
-				<span class="hidden text-sm text-muted-foreground sm:inline">one-time secrets</span>
+			<div class="flex items-center gap-2">
+				<span class="hidden text-sm text-muted-foreground sm:inline">{t('nav.tagline')}</span>
+				<LocaleSwitcher />
 				<ThemeToggle />
 			</div>
 		</div>
@@ -29,6 +37,6 @@
 		{@render children()}
 	</main>
 	<footer class="mx-auto max-w-3xl px-6 py-8 text-center text-sm text-muted-foreground">
-		Encrypted in your browser. The server never sees the key.
+		{t('footer.note')}
 	</footer>
 </div>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { encrypt } from '$lib/crypto';
 	import { createNote } from '$lib/api';
+	import { t } from '$lib/i18n/index.svelte';
 
 	let plaintext = $state('');
 	let expiresIn = $state(3600);
@@ -10,11 +11,11 @@
 	let copied = $state(false);
 
 	const expiryOptions = [
-		{ label: '5 minutes', value: 300 },
-		{ label: '1 hour', value: 3600 },
-		{ label: '1 day', value: 86400 },
-		{ label: '7 days', value: 604800 }
-	];
+		{ key: '5m', value: 300 },
+		{ key: '1h', value: 3600 },
+		{ key: '1d', value: 86400 },
+		{ key: '7d', value: 604800 }
+	] as const;
 
 	async function handleSubmit(e: SubmitEvent) {
 		e.preventDefault();
@@ -49,20 +50,15 @@
 
 <div class="space-y-6">
 	<div>
-		<h1 class="text-3xl font-bold tracking-tight">Share a one-time secret</h1>
-		<p class="mt-2 text-muted-foreground">
-			The secret is encrypted in your browser. The server stores only the ciphertext.
-			The URL is destroyed after a single read.
-		</p>
+		<h1 class="text-3xl font-bold tracking-tight">{t('create.heading')}</h1>
+		<p class="mt-2 text-muted-foreground">{t('create.description')}</p>
 	</div>
 
 	{#if url}
 		<div
 			class="rounded-lg border border-[color:var(--color-border)] bg-card p-6 shadow-sm space-y-4"
 		>
-			<p class="text-sm text-muted-foreground">
-				Share this URL. It works only once.
-			</p>
+			<p class="text-sm text-muted-foreground">{t('create.result_note')}</p>
 			<div class="flex gap-2">
 				<input
 					class="flex-1 rounded-md border border-[color:var(--color-border)] bg-background px-3 py-2 font-mono text-sm"
@@ -75,7 +71,7 @@
 					onclick={copyUrl}
 					class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
 				>
-					{copied ? 'Copied!' : 'Copy'}
+					{copied ? t('create.copied') : t('create.copy')}
 				</button>
 			</div>
 			<button
@@ -83,31 +79,31 @@
 				onclick={reset}
 				class="text-sm text-muted-foreground hover:text-foreground underline"
 			>
-				Create another
+				{t('create.reset')}
 			</button>
 		</div>
 	{:else}
 		<form onsubmit={handleSubmit} class="space-y-4">
 			<label class="block">
-				<span class="text-sm font-medium">Secret</span>
+				<span class="text-sm font-medium">{t('create.label_secret')}</span>
 				<textarea
 					bind:value={plaintext}
 					rows="8"
 					required
 					maxlength="8000"
-					placeholder="Type or paste a secret…"
+					placeholder={t('create.placeholder')}
 					class="mt-1 block w-full rounded-md border border-[color:var(--color-border)] bg-background px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
 				></textarea>
 			</label>
 
 			<label class="block">
-				<span class="text-sm font-medium">Expires in</span>
+				<span class="text-sm font-medium">{t('create.label_expires')}</span>
 				<select
 					bind:value={expiresIn}
 					class="mt-1 block w-full rounded-md border border-[color:var(--color-border)] bg-background px-3 py-2 text-sm"
 				>
 					{#each expiryOptions as opt}
-						<option value={opt.value}>{opt.label}</option>
+						<option value={opt.value}>{t(`create.expiry.${opt.key}`)}</option>
 					{/each}
 				</select>
 			</label>
@@ -121,7 +117,7 @@
 				disabled={submitting || !plaintext.trim()}
 				class="rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
 			>
-				{submitting ? 'Encrypting…' : 'Create one-time URL'}
+				{submitting ? t('create.submitting') : t('create.submit')}
 			</button>
 		</form>
 	{/if}

--- a/web/src/routes/s/[id]/+page.svelte
+++ b/web/src/routes/s/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import { consumeNote, existsNote } from '$lib/api';
 	import { decrypt } from '$lib/crypto';
+	import { t } from '$lib/i18n/index.svelte';
 
 	type View =
 		| { kind: 'checking' }
@@ -51,48 +52,40 @@
 
 <div class="space-y-6">
 	{#if view.kind === 'checking'}
-		<p class="text-muted-foreground">Checking…</p>
+		<p class="text-muted-foreground">{t('reveal.checking')}</p>
 	{:else if view.kind === 'no-key'}
 		<div class="rounded-lg border border-destructive/50 bg-destructive/10 p-6">
-			<h1 class="text-xl font-bold">No key in URL</h1>
-			<p class="mt-2 text-sm text-muted-foreground">
-				This URL is missing the decryption key (the part after <code>#</code>). Without it
-				the secret cannot be decrypted.
-			</p>
+			<h1 class="text-xl font-bold">{t('reveal.no_key_title')}</h1>
+			<p class="mt-2 text-sm text-muted-foreground">{t('reveal.no_key_body')}</p>
 		</div>
 	{:else if view.kind === 'gone'}
 		<div class="rounded-lg border border-[color:var(--color-border)] bg-card p-6">
-			<h1 class="text-xl font-bold">This secret is gone</h1>
-			<p class="mt-2 text-sm text-muted-foreground">
-				It has been read once, or it has expired.
-			</p>
+			<h1 class="text-xl font-bold">{t('reveal.gone_title')}</h1>
+			<p class="mt-2 text-sm text-muted-foreground">{t('reveal.gone_body')}</p>
 		</div>
 	{:else if view.kind === 'ready'}
 		<div class="rounded-lg border border-[color:var(--color-border)] bg-card p-6 space-y-4">
-			<h1 class="text-xl font-bold">A secret is waiting for you</h1>
-			<p class="text-sm text-muted-foreground">
-				Once revealed, it will be permanently deleted from the server. You will not be able
-				to re-open this link.
-			</p>
+			<h1 class="text-xl font-bold">{t('reveal.ready_title')}</h1>
+			<p class="text-sm text-muted-foreground">{t('reveal.ready_body')}</p>
 			<button
 				type="button"
 				onclick={reveal}
 				class="rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
 			>
-				Reveal once
+				{t('reveal.reveal_button')}
 			</button>
 		</div>
 	{:else if view.kind === 'revealing'}
-		<p class="text-muted-foreground">Decrypting…</p>
+		<p class="text-muted-foreground">{t('reveal.revealing')}</p>
 	{:else if view.kind === 'revealed'}
 		<div class="rounded-lg border border-[color:var(--color-border)] bg-card p-6 space-y-3">
-			<p class="text-sm text-muted-foreground">This secret has been destroyed on the server.</p>
+			<p class="text-sm text-muted-foreground">{t('reveal.destroyed_note')}</p>
 			<pre
 				class="whitespace-pre-wrap break-words rounded-md bg-muted p-4 font-mono text-sm">{view.text}</pre>
 		</div>
 	{:else if view.kind === 'error'}
 		<div class="rounded-lg border border-destructive/50 bg-destructive/10 p-6">
-			<h1 class="text-xl font-bold">Failed to decrypt</h1>
+			<h1 class="text-xl font-bold">{t('reveal.error_title')}</h1>
 			<p class="mt-2 text-sm text-muted-foreground">{view.message}</p>
 		</div>
 	{/if}


### PR DESCRIPTION
## Summary
- Svelte 5 runes (\`\$state\`) + JSON 辞書による軽量な自作 i18n を追加 (依存なし)
- 全 UI 文字列 (26 キー + 4 expiry オプション) を \`t()\` に置換
- 初期言語は localStorage → \`navigator.language\` (ja 優先) の順で検出
- ヘッダーに \`<LocaleSwitcher />\` (EN / JA) を追加
- \`<html lang>\` 属性も言語切替時に動的更新

## 翻訳カバレッジ
- [x] layout: title / meta / tagline / footer
- [x] / (作成画面): heading / description / labels / placeholder / expiry options / submit / result / copy / reset
- [x] /s/[id] (復号画面): checking / no-key / gone / ready / revealing / revealed / error
- [x] api.ts: create_failed / read_failed (\`{status}\` 変数差し込み対応)

## Test plan
- [x] \`pnpm build\` & \`pnpm check\` 通過
- [ ] CI: test-api + build-web 緑
- [ ] merge 後、https://burnnote.tommykeyapp.com で EN/JA 切替、全状態 (no-key / ready / gone / error) を日本語で確認
- [ ] リロードで選択言語が維持
- [ ] ブラウザ言語を日本語のまま初回アクセスすると JA で表示される