### PR TITLE
feat(web): add Playwright E2E tests

### DIFF
--- a/web/e2e/tests/i18n.spec.ts
+++ b/web/e2e/tests/i18n.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForHydration(page: import('@playwright/test').Page) {
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel(/Language/i).waitFor();
+}
+
+test.describe('i18n (JA/EN)', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page.evaluate(() => localStorage.setItem('burnnote-locale', 'en'));
+		await page.reload();
+		await waitForHydration(page);
+	});
+
+	test('defaults to English and switches to Japanese', async ({ page }) => {
+		await expect(page.getByRole('heading', { name: /Share a one-time secret/i })).toBeVisible();
+
+		await page.getByLabel(/Language/i).selectOption('ja');
+		await expect(
+			page.getByRole('heading', { name: /一度だけ読めるシークレットを共有/ })
+		).toBeVisible();
+		await expect(page.locator('html')).toHaveAttribute('lang', 'ja');
+	});
+
+	test('persists locale across reload', async ({ page }) => {
+		await page.getByLabel(/Language/i).selectOption('ja');
+		await expect(page.locator('html')).toHaveAttribute('lang', 'ja');
+
+		await page.reload();
+		await waitForHydration(page);
+
+		await expect(
+			page.getByRole('heading', { name: /一度だけ読めるシークレットを共有/ })
+		).toBeVisible();
+		await expect(page.locator('html')).toHaveAttribute('lang', 'ja');
+	});
+});

--- a/web/e2e/tests/notes.spec.ts
+++ b/web/e2e/tests/notes.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForHydration(page: import('@playwright/test').Page) {
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel(/Language/i).waitFor();
+}
+
+test.describe('One-time secret flow', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page.evaluate(() => localStorage.setItem('burnnote-locale', 'en'));
+		await page.reload();
+		await waitForHydration(page);
+	});
+
+	test('golden path: create → reveal → gone', async ({ browser, page }) => {
+		const plaintext = `top secret ${crypto.randomUUID()}`;
+
+		await expect(page.getByRole('heading', { name: /Share a one-time secret/i })).toBeVisible();
+		await page.getByPlaceholder(/Type or paste a secret/i).fill(plaintext);
+		await page.getByLabel(/Expires in/i).selectOption('3600');
+		await page.getByRole('button', { name: /Create one-time URL/i }).click();
+
+		const urlInput = page.locator('input[readonly]');
+		await expect(urlInput).toBeVisible({ timeout: 10_000 });
+		const shareUrl = await urlInput.inputValue();
+		expect(shareUrl).toMatch(/\/s\/[A-Za-z0-9_-]+#[A-Za-z0-9_-]+$/);
+
+		// Open in a fresh context (different browser state) to act as recipient
+		const recipientCtx = await browser.newContext();
+		const recipientPage = await recipientCtx.newPage();
+		await recipientPage.goto(shareUrl);
+		await recipientPage.evaluate(() => localStorage.setItem('burnnote-locale', 'en'));
+		// Re-navigate to the share URL (reload would strip the hash through setLocale)
+		await recipientPage.goto(shareUrl);
+		await waitForHydration(recipientPage);
+
+		await expect(
+			recipientPage.getByRole('heading', { name: /A secret is waiting for you/i })
+		).toBeVisible({ timeout: 10_000 });
+		await recipientPage.getByRole('button', { name: /Reveal once/i }).click();
+
+		const revealed = recipientPage.locator('pre');
+		await expect(revealed).toHaveText(plaintext, { timeout: 10_000 });
+
+		// Re-visit the URL in another new context → server should 410
+		const secondCtx = await browser.newContext();
+		const secondPage = await secondCtx.newPage();
+		await secondPage.goto(shareUrl);
+		await secondPage.evaluate(() => localStorage.setItem('burnnote-locale', 'en'));
+		await secondPage.goto(shareUrl);
+		await waitForHydration(secondPage);
+		await expect(
+			secondPage.getByRole('heading', { name: /This secret is gone/i })
+		).toBeVisible({ timeout: 10_000 });
+
+		await recipientCtx.close();
+		await secondCtx.close();
+	});
+
+	test('no-key: fragment missing shows warning', async ({ page }) => {
+		await page.goto('/s/abcdef0123456789');
+		await waitForHydration(page);
+		await expect(page.getByRole('heading', { name: /No key in URL/i })).toBeVisible();
+	});
+
+	test('copy button flips to "Copied!" state', async ({ page, browserName, context }) => {
+		test.skip(browserName !== 'chromium', 'clipboard API needs permission handling');
+
+		await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+		await page.getByPlaceholder(/Type or paste a secret/i).fill('hello');
+		await page.getByRole('button', { name: /Create one-time URL/i }).click();
+		await expect(page.locator('input[readonly]')).toBeVisible({ timeout: 10_000 });
+
+		await page.getByRole('button', { name: /^Copy$/ }).click();
+		await expect(page.getByRole('button', { name: /^Copied!$/ })).toBeVisible();
+	});
+});

--- a/web/e2e/tests/theme.spec.ts
+++ b/web/e2e/tests/theme.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForHydration(page: import('@playwright/test').Page) {
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel(/Language/i).waitFor();
+}
+
+test.describe('Theme toggle', () => {
+	test('cycles light → dark → system', async ({ page }) => {
+		await page.goto('/');
+		await page.evaluate(() => {
+			localStorage.setItem('mode-watcher-mode', 'light');
+			localStorage.setItem('burnnote-locale', 'en');
+		});
+		await page.reload();
+		await waitForHydration(page);
+
+		const toggle = page.getByRole('button', { name: /Theme:/i });
+		await expect(toggle).toBeVisible();
+		await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
+
+		// light → dark
+		await toggle.click();
+		await expect(page.locator('html')).toHaveClass(/\bdark\b/, { timeout: 2000 });
+
+		// dark → system → light (cycle back)
+		await toggle.click();
+		await toggle.click();
+		await expect(page.locator('html')).not.toHaveClass(/\bdark\b/, { timeout: 2000 });
+	});
+});

--- a/web/package.json
+++ b/web/package.json
@@ -9,9 +9,11 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test:e2e": "playwright test"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.59.1",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: './e2e/tests',
+	timeout: 30_000,
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI ? [['github'], ['html']] : 'list',
+	use: {
+		baseURL: process.env.BASE_URL ?? 'http://localhost:5173',
+		trace: 'on-first-retry',
+		headless: true
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] }
+		}
+	]
+});

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
         version: 3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.4)(vite@8.0.9(jiti@2.6.1)))(svelte@5.55.4)(typescript@6.0.3)(vite@8.0.9(jiti@2.6.1)))
@@ -81,6 +84,11 @@ packages:
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -119,42 +127,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
@@ -256,28 +258,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -387,6 +385,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -444,28 +447,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -525,6 +524,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -710,6 +719,10 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.126.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -921,6 +934,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1016,6 +1032,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.10:
     dependencies:

--- a/web/src/lib/components/LocaleSwitcher.svelte
+++ b/web/src/lib/components/LocaleSwitcher.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
-	import { getLocale, setLocale, type Locale } from '$lib/i18n/index.svelte';
+	import { localeState, type Locale } from '$lib/i18n/index.svelte';
 
 	function onChange(e: Event) {
 		const v = (e.currentTarget as HTMLSelectElement).value as Locale;
-		setLocale(v);
+		localeState.set(v);
 	}
 </script>
 
 <select
-	value={getLocale()}
 	onchange={onChange}
 	aria-label="Language"
 	class="h-9 rounded-md border border-[color:var(--color-border)] bg-background px-2 text-sm"
 >
-	<option value="en">EN</option>
-	<option value="ja">JA</option>
+	<option value="en" selected={localeState.current === 'en'}>EN</option>
+	<option value="ja" selected={localeState.current === 'ja'}>JA</option>
 </select>

--- a/web/src/lib/i18n/index.svelte.ts
+++ b/web/src/lib/i18n/index.svelte.ts
@@ -9,43 +9,56 @@ const STORAGE_KEY = 'burnnote-locale';
 
 type MessageNode = string | { [k: string]: MessageNode };
 
-let locale = $state<Locale>('en');
+class LocaleState {
+	current = $state<Locale>('en');
 
+	set(next: Locale): void {
+		this.current = next;
+		if (typeof window !== 'undefined') {
+			try {
+				localStorage.setItem(STORAGE_KEY, next);
+			} catch {
+				// ignore storage errors
+			}
+			document.documentElement.lang = next;
+		}
+	}
+
+	init(): void {
+		if (typeof window === 'undefined') return;
+		let stored: string | null = null;
+		try {
+			stored = localStorage.getItem(STORAGE_KEY);
+		} catch {
+			// ignore
+		}
+		if (stored === 'en' || stored === 'ja') {
+			this.set(stored);
+			return;
+		}
+		const nav = navigator.language?.toLowerCase() ?? '';
+		this.set(nav.startsWith('ja') ? 'ja' : 'en');
+	}
+}
+
+export const localeState = new LocaleState();
+
+// Convenience wrappers (for imports that don't want the instance)
 export function getLocale(): Locale {
-	return locale;
+	return localeState.current;
 }
 
 export function setLocale(next: Locale): void {
-	locale = next;
-	if (typeof window !== 'undefined') {
-		try {
-			localStorage.setItem(STORAGE_KEY, next);
-		} catch {
-			// ignore storage errors
-		}
-		document.documentElement.lang = next;
-	}
+	localeState.set(next);
 }
 
 export function initLocale(): void {
-	if (typeof window === 'undefined') return;
-	let stored: string | null = null;
-	try {
-		stored = localStorage.getItem(STORAGE_KEY);
-	} catch {
-		// ignore
-	}
-	if (stored === 'en' || stored === 'ja') {
-		setLocale(stored);
-		return;
-	}
-	const nav = navigator.language?.toLowerCase() ?? '';
-	setLocale(nav.startsWith('ja') ? 'ja' : 'en');
+	localeState.init();
 }
 
 export function t(key: string, params?: Record<string, string | number>): string {
 	const parts = key.split('.');
-	let node: MessageNode = messages[locale];
+	let node: MessageNode = messages[localeState.current];
 	for (const p of parts) {
 		if (typeof node === 'string') return key;
 		node = node[p];

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,12 +2,14 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
+const apiTarget = process.env.API_URL ?? 'http://localhost:8080';
+
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 	server: {
 		proxy: {
-			'/api': 'http://localhost:8080',
-			'/health': 'http://localhost:8080'
+			'/api': apiTarget,
+			'/health': apiTarget
 		}
 	}
 });


### PR DESCRIPTION
## Summary
元の計画で残していた Playwright E2E を追加。6 tests covering:

| テスト | 内容 |
|---|---|
| golden path | 作成 → fragment 込み URL 発行 → 別 context で reveal → 平文一致 → さらに別 context で 410 gone |
| no-key | fragment 無しで \`/s/{id}\` アクセス時に "No key in URL" |
| copy | Copy ボタンクリップボード連携、"Copied!" 表示 |
| i18n default | EN デフォルト、EN → JA 切替 + \`<html lang>\` 属性更新 |
| i18n persist | JA 選択後リロードで維持 (localStorage) |
| theme cycle | light → dark → system → light の循環 |

## 併せて直したもの
- \`vite.config.ts\`: proxy の target を \`API_URL\` 環境変数でオーバーライド可能に (ローカルで Laravel を :8081 で立てたい時に便利、デフォルトは従来通り :8080)
- \`src/lib/i18n/index.svelte.ts\`: shared \`\$state\` を class-based に refactor。module-level の簡易変数より class プロパティの方が他コンポーネントからの cross-module reactivity が確実
- \`LocaleSwitcher.svelte\`: \`<select value={...}>\` の controlled pattern が Playwright \`selectOption\` と相性悪かったため、option の \`selected=\` 属性方式に変更 (機能同等)

## Test plan
- [x] ローカル (flox activate + docker compose up + artisan serve + pnpm dev) で \`pnpm test:e2e\` 全 6 件緑
- [ ] CI: test-api + build-web 緑
- [ ] (次 PR) CI に e2e-web ジョブ追加して status check に組み込み