### PR TITLE
ci: add e2e-web job for Playwright

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,3 +52,98 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
         working-directory: web
+
+  e2e-web:
+    runs-on: ubuntu-latest
+    services:
+      dynamodb-local:
+        image: amazon/dynamodb-local:latest
+        ports:
+          - 8000:8000
+    env:
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      DYNAMODB_ENDPOINT: http://127.0.0.1:8000
+      DYNAMODB_TABLE: burnnote
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, curl, bcmath, intl
+          coverage: none
+          tools: composer:v2
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install PHP deps
+        run: composer install --no-interaction --prefer-dist
+        working-directory: api
+
+      - name: Install Node deps
+        run: pnpm install --frozen-lockfile
+        working-directory: web
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+        working-directory: web
+
+      - name: Create DynamoDB table
+        run: |
+          aws dynamodb create-table \
+            --table-name burnnote \
+            --attribute-definitions AttributeName=id,AttributeType=S \
+            --key-schema AttributeName=id,KeyType=HASH \
+            --billing-mode PAY_PER_REQUEST \
+            --endpoint-url http://127.0.0.1:8000 \
+            --region ap-northeast-1
+
+      - name: Start Laravel
+        run: |
+          nohup php artisan serve --host=127.0.0.1 --port=8080 > /tmp/laravel.log 2>&1 &
+          for i in {1..30}; do
+            curl -sf http://127.0.0.1:8080/health > /dev/null && break
+            sleep 1
+          done
+          curl -sf http://127.0.0.1:8080/health
+        working-directory: api
+
+      - name: Start SvelteKit dev
+        run: |
+          nohup pnpm dev --host 127.0.0.1 --port 5173 > /tmp/sveltekit.log 2>&1 &
+          for i in {1..30}; do
+            curl -sf http://127.0.0.1:5173/ > /dev/null && break
+            sleep 1
+          done
+          curl -sfI http://127.0.0.1:5173/
+        working-directory: web
+
+      - name: Run Playwright tests
+        run: pnpm test:e2e
+        working-directory: web
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 7
+
+      - name: Dump service logs on failure
+        if: failure()
+        run: |
+          echo '--- laravel.log ---'
+          cat /tmp/laravel.log || true
+          echo '--- sveltekit.log ---'
+          cat /tmp/sveltekit.log || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,32 @@ jobs:
             --endpoint-url http://127.0.0.1:8000 \
             --region ap-northeast-1
 
+      - name: Create .env for artisan serve
+        run: |
+          cat > .env <<EOF
+          APP_NAME=burnnote
+          APP_ENV=testing
+          APP_KEY=base64:$(openssl rand -base64 32)
+          APP_DEBUG=true
+          APP_URL=http://127.0.0.1:8080
+          LOG_CHANNEL=stderr
+          LOG_LEVEL=debug
+          DB_CONNECTION=null
+          SESSION_DRIVER=array
+          CACHE_STORE=array
+          QUEUE_CONNECTION=sync
+          BROADCAST_CONNECTION=log
+          FILESYSTEM_DISK=local
+          DYNAMODB_TABLE=burnnote
+          DYNAMODB_ENDPOINT=http://127.0.0.1:8000
+          AWS_REGION=ap-northeast-1
+          AWS_ACCESS_KEY_ID=test
+          AWS_SECRET_ACCESS_KEY=test
+          BURNNOTE_MAX_CIPHERTEXT_BYTES=16384
+          BURNNOTE_MAX_EXPIRES_SEC=604800
+          EOF
+        working-directory: api
+
       - name: Start Laravel
         run: |
           nohup php artisan serve --host=127.0.0.1 --port=8080 > /tmp/laravel.log 2>&1 &
@@ -117,6 +143,12 @@ jobs:
           done
           curl -sf http://127.0.0.1:8080/health
         working-directory: api
+
+      - name: Smoke test API (POST /api/notes)
+        run: |
+          curl -sfw '\n[%{http_code}]\n' -X POST http://127.0.0.1:8080/api/notes \
+            -H 'Content-Type: application/json' \
+            -d '{"ciphertext":"Y2lwaGVy","iv":"MTIzNDU2Nzg5MGFi","expires_in":3600}'
 
       - name: Start SvelteKit dev
         run: |


### PR DESCRIPTION
## Summary
PR #8 で追加した Playwright E2E を CI で自動実行する。

## 構成
- \`services:\` で \`amazon/dynamodb-local:latest\` を立ち上げ (port 8000)
- \`setup-php@v2\` (8.4) + \`setup-node@v4\` (22) + \`pnpm@10\`
- Laravel を \`php artisan serve :8080\` でバックグラウンド起動、\`/health\` をヘルスチェック
- SvelteKit を \`pnpm dev :5173\` でバックグラウンド起動、ルートをヘルスチェック
- \`playwright install --with-deps chromium\` (CI の sudo は使えるので OK)
- \`pnpm test:e2e\` を実行

## 成果物
- \`playwright-report/\` を \`actions/upload-artifact@v4\` で 7 日保存
- 失敗時は Laravel / SvelteKit の stdout/stderr も dump

## Test plan
- [x] ローカルで E2E 6 件が通ることは PR #8 で確認済
- [ ] この PR の CI で \`e2e-web\` ジョブが緑になる
- [ ] 失敗時は playwright-report artifact が取れる
- [ ] (後続) ruleset の \`required_status_checks\` に \`e2e-web\` 追加