### PR TITLE
feat(infra): add CloudWatch dashboard

### DIFF
--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -1,0 +1,201 @@
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = var.project
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 2
+        properties = {
+          markdown = "# burnnote operations dashboard\n**Domain:** ${var.domain} | **Region:** ${var.region} | **State:** s3://tommykeyapp-tfstate/burnnote/terraform.tfstate"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 2
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Lambda — invocations / errors / throttles"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          metrics = [
+            ["AWS/Lambda", "Invocations", "FunctionName", aws_lambda_function.api.function_name, { stat = "Sum" }],
+            [".", "Errors", ".", ".", { stat = "Sum", color = "#d13212" }],
+            [".", "Throttles", ".", ".", { stat = "Sum", color = "#ff7f0e" }]
+          ]
+          period = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 2
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Lambda — duration (p50 / p95 / p99)"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          metrics = [
+            ["AWS/Lambda", "Duration", "FunctionName", aws_lambda_function.api.function_name, { stat = "p50", label = "p50" }],
+            ["...", { stat = "p95", label = "p95" }],
+            ["...", { stat = "p99", label = "p99" }]
+          ]
+          period = 300
+          yAxis = {
+            left = {
+              label = "ms"
+              min   = 0
+            }
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 8
+        width  = 12
+        height = 6
+        properties = {
+          title   = "API Gateway — request count & errors"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          metrics = [
+            ["AWS/ApiGateway", "Count", "ApiId", aws_apigatewayv2_api.api.id, { stat = "Sum" }],
+            [".", "4xx", ".", ".", { stat = "Sum", color = "#ff7f0e" }],
+            [".", "5xx", ".", ".", { stat = "Sum", color = "#d13212" }]
+          ]
+          period = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 8
+        width  = 12
+        height = 6
+        properties = {
+          title   = "API Gateway — integration latency"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          metrics = [
+            ["AWS/ApiGateway", "IntegrationLatency", "ApiId", aws_apigatewayv2_api.api.id, { stat = "p50", label = "p50" }],
+            ["...", { stat = "p95", label = "p95" }],
+            ["...", { stat = "p99", label = "p99" }]
+          ]
+          period = 300
+          yAxis = {
+            left = {
+              label = "ms"
+              min   = 0
+            }
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 14
+        width  = 12
+        height = 6
+        properties = {
+          title   = "DynamoDB — consumed capacity & throttles"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          metrics = [
+            ["AWS/DynamoDB", "ConsumedReadCapacityUnits", "TableName", aws_dynamodb_table.notes.name, { stat = "Sum", label = "Read RCU" }],
+            [".", "ConsumedWriteCapacityUnits", ".", ".", { stat = "Sum", label = "Write WCU" }],
+            [".", "ReadThrottleEvents", ".", ".", { stat = "Sum", color = "#d13212" }],
+            [".", "WriteThrottleEvents", ".", ".", { stat = "Sum", color = "#d13212" }]
+          ]
+          period = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 14
+        width  = 12
+        height = 6
+        properties = {
+          title   = "DynamoDB — user errors & latency"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          metrics = [
+            ["AWS/DynamoDB", "UserErrors", { stat = "Sum" }],
+            ["AWS/DynamoDB", "SuccessfulRequestLatency", "TableName", aws_dynamodb_table.notes.name, "Operation", "PutItem", { stat = "Average", label = "PutItem p50" }],
+            [".", ".", ".", ".", ".", "DeleteItem", { stat = "Average", label = "DeleteItem p50" }],
+            [".", ".", ".", ".", ".", "GetItem", { stat = "Average", label = "GetItem p50" }]
+          ]
+          period = 300
+          yAxis = {
+            left = {
+              label = "ms / count"
+              min   = 0
+            }
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 20
+        width  = 12
+        height = 6
+        properties = {
+          title   = "CloudFront — requests & error rate (us-east-1)"
+          region  = "us-east-1"
+          view    = "timeSeries"
+          stacked = false
+          metrics = [
+            ["AWS/CloudFront", "Requests", "DistributionId", aws_cloudfront_distribution.frontend.id, "Region", "Global", { stat = "Sum" }],
+            [".", "4xxErrorRate", ".", ".", ".", ".", { stat = "Average", color = "#ff7f0e", yAxis = "right" }],
+            [".", "5xxErrorRate", ".", ".", ".", ".", { stat = "Average", color = "#d13212", yAxis = "right" }]
+          ]
+          period = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 20
+        width  = 12
+        height = 6
+        properties = {
+          title   = "CloudFront — bytes downloaded (us-east-1)"
+          region  = "us-east-1"
+          view    = "timeSeries"
+          stacked = false
+          metrics = [
+            ["AWS/CloudFront", "BytesDownloaded", "DistributionId", aws_cloudfront_distribution.frontend.id, "Region", "Global", { stat = "Sum" }]
+          ]
+          period = 300
+        }
+      },
+      {
+        type   = "log"
+        x      = 0
+        y      = 26
+        width  = 24
+        height = 6
+        properties = {
+          title  = "Lambda errors (recent)"
+          region = var.region
+          query  = "SOURCE '${aws_cloudwatch_log_group.lambda.name}' | fields @timestamp, @message | filter @message like /ERROR|Error|Exception/ | sort @timestamp desc | limit 50"
+          view   = "table"
+        }
+      }
+    ]
+  })
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -29,3 +29,7 @@ output "frontend_bucket_name" {
 output "public_url" {
   value = "https://${var.domain}"
 }
+
+output "dashboard_url" {
+  value = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${aws_cloudwatch_dashboard.main.dashboard_name}"
+}


### PR DESCRIPTION
## Summary
\`burnnote\` という名前の CloudWatch Dashboard を Terraform 管理下に追加。

## 構成
- Lambda — Invocations / Errors / Throttles + Duration p50/p95/p99
- API Gateway — Count / 4xx / 5xx + IntegrationLatency p50/p95/p99
- DynamoDB — ConsumedR/WCU + Throttle + UserErrors + PutItem/DeleteItem/GetItem p50 latency
- CloudFront (us-east-1) — Requests + 4xx/5xxErrorRate + BytesDownloaded
- Lambda errors tail (CloudWatch Logs Insights query)

\`dashboard_url\` output も追加。

## Test plan
- [x] \`terraform validate\` 成功
- [ ] CI: test-api + build-web + e2e-web 緑
- [ ] merge 後 CD の deploy-infra で \`aws_cloudwatch_dashboard.main\` がプロビジョニング
- [ ] \`terraform output dashboard_url\` のリンクで Dashboard 表示