### PR TITLE
fix(docs): escape colon inside Swagger YAML description

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -93,7 +93,7 @@ paths:
   /health:
     get:
       summary: Health check
-      description: Laravel health ルート (`Application::withRouting(health: '/health')`)
+      description: "Laravel health ルート (`Application::withRouting(health: '/health')`)"
       responses:
         '200':
           description: OK


### PR DESCRIPTION
## Summary
\`https://tommykey-apps.github.io/burnnote/\` で \"Unable to render this definition\" が出ていた原因を修正。

\`docs/swagger.yaml\` 96 行目:

\`\`\`yaml
description: Laravel health ルート (\`Application::withRouting(health: '/health')\`)
\`\`\`

バッククォート内の \`health:\` を YAML パーサが nested mapping key として解釈し、全体パースが失敗していた (\`mapping values are not allowed here, line 96 column 72\`)。

description を double quote で囲んでスカラーとして扱わせる。

## Test plan
- [x] \`python3 -c 'import yaml; yaml.safe_load(open(\"swagger.yaml\"))'\` 成功
- [ ] CI: test-api + build-web + e2e-web 緑
- [ ] merge 後 pages.yaml が走って Swagger UI が正しくレンダリング