### PR TITLE
ci: PR で terraform plan を走らせる check を追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,3 +179,18 @@ jobs:
           cat /tmp/laravel.log || true
           echo '--- sveltekit.log ---'
           cat /tmp/sveltekit.log || true
+
+  terraform-plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - uses: tommykey-apps/.github/.github/actions/terraform-plan@v1
+        with:
+          working-directory: infra


### PR DESCRIPTION
## Summary

\`tommykey-apps/.github\` の \`terraform-plan\` composite action (v1) を burnnote の CI に組み込む。これで PR 時点で \`terraform plan\` が走り、\`infra/\` の問題が main マージ前に検知できる。

## Changes

- \`.github/workflows/ci.yaml\` に \`terraform-plan\` job を追加
  - AWS credentials は既存 secrets を流用
  - \`infra/variables.tf\` の variable は全て default 持ちなので \`TF_VAR_*\` 不要

## Test plan

- [ ] この PR で \`terraform-plan\` job が緑になる
- [x] composite action は chat (#124) で動作実績あり、Wave 1 として burnnote で再確認

Fixes #14